### PR TITLE
Added IJCAI, ACL, AISTATS, and JMLR

### DIFF
--- a/config.py
+++ b/config.py
@@ -79,5 +79,37 @@ CONFERENCES = {
         'timeout': 45,
         'rate_limit_delay': 120, 
         'years': [2019, 2020, 2021, 2022, 2023, 2024, 2025]
+    }, 
+    'aistats' : {
+        'name': 'AISTATS',
+        'base_url': 'https://proceedings.mlr.press/',
+        'request_delay': 0.15,
+        'retry_attempts': 3,
+        'timeout': 45,
+        'rate_limit_delay': 120,
+    }, 
+    'jmlr' : {
+        'name': 'JMLR',
+        'base_url': 'https://www.jmlr.org',
+        'request_delay': 0.15,
+        'retry_attempts': 3,
+        'timeout': 45,
+        'rate_limit_delay': 120,
+    }, 
+    'acl' : {
+        'name': 'ACL',
+        'base_url': 'https://aclanthology.org', 
+        'request_delay': 0.15,
+        'retry_attempts': 3,
+        'timeout': 45,
+        'rate_limit_delay': 120,
+    }, 
+    'ijcai' : {
+        'name': 'IJCAI',
+        'base_url': 'https://www.ijcai.org/',
+        'request_delay': 0.15,
+        'retry_attempts': 3,
+        'timeout': 45,
+        'rate_limit_delay': 120,
     }
 }

--- a/main.py
+++ b/main.py
@@ -14,6 +14,10 @@ from scrapers.cvpr import CVPRScraper
 from scrapers.colt import COLTScraper
 from scrapers.uai import UAIScraper 
 from scrapers.uai_1518 import UAIScraper1518
+from scrapers.aistats import AISTATSScraper
+from scrapers.jmlr import JMLRScraper  
+from scrapers.acl import ACLScraper
+from scrapers.ijcai import IJCAIScraper
 from config import CONFERENCES
 
 # Configure logging
@@ -40,7 +44,11 @@ class ScraperFactory:
             'aaai': AAAIScraper,
             'cvpr': CVPRScraper, 
             'colt': COLTScraper,
-            'uai': UAIScraper   
+            'uai': UAIScraper, 
+            'aistats': AISTATSScraper, 
+            'jmlr': JMLRScraper, 
+            'acl': ACLScraper, 
+            'ijcai': IJCAIScraper 
         }
         
         # Year-specific scraper mappings

--- a/scrapers/acl.py
+++ b/scrapers/acl.py
@@ -1,167 +1,211 @@
 # scrapers/template.py
 """Template for implementing new conference scrapers."""
 
+
 from typing import List, Dict, Optional
 import logging
 from bs4 import BeautifulSoup
-
+import os
+import json
 from .base import BaseScraper
+
 
 logger = logging.getLogger(__name__)
 
 
+
+
 class ACLScraper(BaseScraper):
-    """ACL scraper - copy this to create new conference scrapers."""
-
-    def __init__(self):
-        # Replace 'template' with actual conference name (must match config.py)
-        super().__init__('acl')
-    
-
-    def get_conference_url(self, year: int) -> str: 
-        try: 
-            import re
-            url = f"{self.base_url}/events/acl-{year}/" # https://aclanthology.org/events/acl-2023/
-            response = self.session.get(url)
-            if not response:
-                return 'invalid url'
-            soup = BeautifulSoup(response.content, 'html.parser')
-            a_tags = soup.find_all('a', href=True, class_='align-middle')
-            for a in a_tags: 
-                if a.find_parent('h4'):
-                    if re.search(r'\bProceedings\s+of\s+the\s+\d{2}(st|nd|rd|th)\s+Annual\s+Meeting\s+of\s+the\s+Association\s+for\s+Computational\s+Linguistics\b', a.text, re.IGNORECASE):
-                        href = a['href']
-                        if href:
-                            return self.base_url + href
-        except Exception as e:
-            logger.error(f"Failed to get conference URL: {e}")
-            return "Could not find the conference URL"
-        
-
-    def get_paper_urls(self, year: int) -> List[str]:
-        """Get paper URLs for a given year."""
-        logger.info(f"Getting {self.config['name']} {year} paper URLs...")
-        try:
-            url = self.get_conference_url(year)
-            paper_urls = []
-            response = self.session.get(url)
-            if not response: 
-                return []
-            soup = BeautifulSoup(response.content, 'html.parser')
-            strong_tags = soup.find_all('strong')
-            for strong_tag in strong_tags[1:]:
-                a = strong_tag.find('a', href=True, class_='align-middle')
-                if a:
-                    paper_urls.append(self.base_url + a['href'])
-            logger.info(f"Found {len(paper_urls)} paper URLs")
-            return paper_urls
-            
-        except Exception as e:
-            logger.error(f"Failed to get paper URLs: {e}")
-            return []
-    
-    def parse_paper(self, url: str) -> Optional[Dict]:
-        """Parse a single paper."""
-        try:
-            response = self.session.get(url)
-            if not response:
-                return None
-            
-            soup = BeautifulSoup(response.content, 'html.parser')
-            
-            # TODO: Implement conference-specific parsing
-            # Common elements to extract:
-            
-            # 1. Title
-            title = self._extract_title(soup)
-            if not title:
-                logger.warning(f"No title found for {url}")
-                return None
-            
-            # 2. Authors
-            authors = self._extract_authors(soup)
-            
-            # 3. Abstract
-            abstract = self._extract_abstract(soup)
-            
-            # 4. Paper ID
-            paper_id = self._extract_paper_id(url)
-            
-            # 5. PDF URL
-            pdf_url = self._extract_pdf_url(soup, url)
-            
-            paper = {
-                'id': paper_id,
-                'title': title,
-                'authors': authors,
-                'abstract': abstract,
-                'pdf_url': pdf_url
-            }
-            
-            logger.debug(f"Parsed: {title}")
-            return paper
-            
-        except Exception as e:
-            logger.error(f"Failed to parse {url}: {e}")
-            return None
-    
-    def _extract_title(self, soup: BeautifulSoup) -> str:
-        title = ""
-        title = soup.find('h2', id='title')
-        if title:
-            return title.get_text().strip()
-        return "failed"
-    
-    def _extract_authors(self, soup: BeautifulSoup) -> List[str]:
-        authors = []
-        p_tag = soup.find('p', class_='lead')
-        if p_tag: 
-            a_tags = p_tag.find_all('a', href=True)
-            for a in a_tags:
-                authors.append(a.get_text().strip())
-            return authors
-        return []
-    
-    def _extract_abstract(self, soup: BeautifulSoup) -> str:
-       abstract = ""
-       h5_tag = soup.find('h5', class_='card-title')
-       if h5_tag: 
-           abstract = h5_tag.find_next_sibling('span').get_text().strip()
-       return abstract if abstract else "No abstract found"
-
-    
-    def _extract_paper_id(self, url: str) -> str:
-        import re
-        match = re.search(r'https://aclanthology.org/(.*)', url)
-        paper_id_with_slash = match.group(1) if match else ""
-        return paper_id_with_slash.rstrip('/')
-    
-    def _extract_pdf_url(self, soup: BeautifulSoup, page_url: str) -> str:
-        dt_tag = soup.find('dt', string='PDF:')
-        dd_tag = dt_tag.find_next_sibling('dd') if dt_tag else None
-        if dd_tag and dd_tag.a:
-            return dd_tag.a['href']
-        return ""
-    
-    def _make_absolute_url(self, url: str) -> str:
-        """Convert relative URL to absolute."""
-        from urllib.parse import urljoin
-        return urljoin(self.base_url, url)
+   """ACL scraper - copy this to create new conference scrapers."""
 
 
-# Example scrapers for reference:
+   def __init__(self):
+       super().__init__('acl')
+   def labeled_json_exists(self) -> bool:
+       return os.path.exists("data/acl/labeled.json")
+  
+   def load_labeled_tracks(self) -> dict:
+       with open("data/acl/labeled.json") as f:
+           return json.load(f)
+      
+   def get_relevant_tracks(self, year: int, labeled_tracks: dict) -> list:
+       year_str = str(year)
+       if year_str not in labeled_tracks:
+           return []
+       relevant_tracks = []
+       for track in labeled_tracks[year_str]["tracks"]:
+           if track.get("is_full_regular"):
+               relevant_tracks.append(track["name"].lower())
+       return relevant_tracks
+  
+   def get_track_names(self, year: int) -> list:
+       url = f"{self.base_url}/events/acl-{year}/"
+       response = self.session.get(url)
+       if not response:
+           logger.error(f"Failed to fetch {url}")
+           return []
+       soup = BeautifulSoup(response.content, 'html.parser')
+       track_names = []
+       a_tags = [a for a in soup.find_all('a', href=True) if a.get('class') == ['align-middle']] # some stuff contain align-middle as class name somewhere... so im making it so that it HAS TO ONLY BE align-middle
+       for a in a_tags:
+           if a.find_parent('h4', class_="d-sm-flex pb-2 border-bottom"):
+               track_names.append(a.get_text(strip=True).lower())
+       return track_names
+              
+   def get_conference_urls(self, year: int, relevant_tracks: list) -> list:
+       try:
+           url = f"{self.base_url}/events/acl-{year}/"
+           response = self.session.get(url)
+           if not response:
+               return []
+           soup = BeautifulSoup(response.content, 'html.parser')
+           urls = []
+           a_tags = [a for a in soup.find_all('a', href=True) if a.get('class') == ['align-middle']]
+           for a in a_tags:
+               if a.find_parent('h4', class_="d-sm-flex pb-2 border-bottom"):
+                   track_name = a.get_text(strip=True).lower()
+                   if track_name in relevant_tracks:
+                       href = a['href']
+                       if href:
+                           urls.append(self.base_url + href)
+           return urls
+       except Exception as e:
+           logger.error(f"Failed to get conference URLs: {e}")
+           return []
+      
 
-class ICMLScraper(BaseScraper):
-    """ICML scraper - proceedings.mlr.press"""
-    
-    def __init__(self):
-        super().__init__('icml')
-    
-    def get_paper_urls(self, year: int) -> List[str]:
-        # ICML uses volume numbers, need to map year to volume
-        # This would need to be implemented based on ICML's structure
-        pass
-    
-    def parse_paper(self, url: str) -> Optional[Dict]:
-        # ICML has a specific format on MLR Press
-        pass
+
+   def get_paper_urls(self, year: int) -> List[str]:
+       """Get paper URLs for a given year."""
+       logger.info(f"Getting {self.config['name']} {year} paper URLs...")
+       year_str = str(year)
+       if self.labeled_json_exists():
+           labeled_tracks = self.load_labeled_tracks()
+           if year_str in labeled_tracks:
+               relevant_tracks = self.get_relevant_tracks(year, labeled_tracks)
+               logger.info(f"Relevant tracks for {year}: {relevant_tracks}")
+               urls = self.get_conference_urls(year, relevant_tracks)
+               paper_urls = []
+               for url in urls:
+                   logger.info(f"Found URL: {url}")
+                   response = self.session.get(url)
+                   if not response:
+                       continue
+                   soup = BeautifulSoup(response.content, 'html.parser')
+                   strong_tags = soup.find_all('strong')
+                   for strong_tag in strong_tags[1:]:
+                       a = strong_tag.find('a', href=True, class_='align-middle')
+                       if a:
+                           paper_urls.append(self.base_url + a['href'])
+               logger.info(f"Found {len(paper_urls)} paper URLs")
+               return paper_urls           
+      
+       all_tracks = self.get_track_names(year)
+       unlabeled_json = {
+           year_str: {
+               "tracks": [{"name": t} for t in all_tracks]
+           }
+       }
+       os.makedirs("data/acl", exist_ok=True)
+       with open(f"data/acl/unlabeled_{year}.json", "w") as f:
+           json.dump(unlabeled_json, f, indent=2)
+       logger.warning(
+           f"Unlabeled track list for {year} written to data/acl/unlabeled_{year}.json. "
+           "Please label this file using GPT and save as data/acl/labeled.json, then rerun."
+       )
+       exit(0)
+   def parse_paper(self, url: str) -> Optional[Dict]:
+       """Parse a single paper."""
+       try:
+           response = self.session.get(url)
+           if not response:
+               return None
+          
+           soup = BeautifulSoup(response.content, 'html.parser')
+          
+           # TODO: Implement conference-specific parsing
+           # Common elements to extract:
+          
+           # 1. Title
+           title = self._extract_title(soup)
+           if not title:
+               logger.warning(f"No title found for {url}")
+               return None
+          
+           # 2. Authors
+           authors = self._extract_authors(soup)
+          
+           # 3. Abstract
+           abstract = self._extract_abstract(soup)
+          
+           # 4. Paper ID
+           paper_id = self._extract_paper_id(url)
+          
+           # 5. PDF URL
+           pdf_url = self._extract_pdf_url(soup, url)
+          
+           paper = {
+               'id': paper_id,
+               'title': title,
+               'authors': authors,
+               'abstract': abstract,
+               'pdf_url': pdf_url
+           }
+          
+           logger.debug(f"Parsed: {title}")
+           return paper
+          
+       except Exception as e:
+           logger.error(f"Failed to parse {url}: {e}")
+           return None
+  
+   def _extract_title(self, soup: BeautifulSoup) -> str:
+       title = ""
+       title = soup.find('h2', id='title')
+       if title:
+           return title.get_text().strip()
+       return "failed"
+  
+   def _extract_authors(self, soup: BeautifulSoup) -> List[str]:
+       authors = []
+       p_tag = soup.find('p', class_='lead')
+       if p_tag:
+           a_tags = p_tag.find_all('a', href=True)
+           for a in a_tags:
+               authors.append(a.get_text().strip())
+           return authors
+       return []
+  
+   def _extract_abstract(self, soup: BeautifulSoup) -> str:
+      abstract = ""
+      h5_tag = soup.find('h5', class_='card-title')
+      if h5_tag:
+          abstract = h5_tag.find_next_sibling('span').get_text().strip()
+      return abstract if abstract else "No abstract found"
+
+
+  
+   def _extract_paper_id(self, url: str) -> str:
+       import re
+       match = re.search(r'https://aclanthology.org/(.*)', url)
+       paper_id_with_slash = match.group(1) if match else ""
+       return paper_id_with_slash.rstrip('/')
+  
+   def _extract_pdf_url(self, soup: BeautifulSoup, page_url: str) -> str:
+       dt_tag = soup.find('dt', string='PDF:')
+       dd_tag = dt_tag.find_next_sibling('dd') if dt_tag else None
+       if dd_tag and dd_tag.a:
+           return dd_tag.a['href']
+       return ""
+  
+   def _make_absolute_url(self, url: str) -> str:
+       """Convert relative URL to absolute."""
+       from urllib.parse import urljoin
+       return urljoin(self.base_url, url)
+
+
+
+
+
+
+

--- a/scrapers/acl.py
+++ b/scrapers/acl.py
@@ -1,0 +1,167 @@
+# scrapers/template.py
+"""Template for implementing new conference scrapers."""
+
+from typing import List, Dict, Optional
+import logging
+from bs4 import BeautifulSoup
+
+from .base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+
+class ACLScraper(BaseScraper):
+    """ACL scraper - copy this to create new conference scrapers."""
+
+    def __init__(self):
+        # Replace 'template' with actual conference name (must match config.py)
+        super().__init__('acl')
+    
+
+    def get_conference_url(self, year: int) -> str: 
+        try: 
+            import re
+            url = f"{self.base_url}/events/acl-{year}/" # https://aclanthology.org/events/acl-2023/
+            response = self.session.get(url)
+            if not response:
+                return 'invalid url'
+            soup = BeautifulSoup(response.content, 'html.parser')
+            a_tags = soup.find_all('a', href=True, class_='align-middle')
+            for a in a_tags: 
+                if a.find_parent('h4'):
+                    if re.search(r'\bProceedings\s+of\s+the\s+\d{2}(st|nd|rd|th)\s+Annual\s+Meeting\s+of\s+the\s+Association\s+for\s+Computational\s+Linguistics\b', a.text, re.IGNORECASE):
+                        href = a['href']
+                        if href:
+                            return self.base_url + href
+        except Exception as e:
+            logger.error(f"Failed to get conference URL: {e}")
+            return "Could not find the conference URL"
+        
+
+    def get_paper_urls(self, year: int) -> List[str]:
+        """Get paper URLs for a given year."""
+        logger.info(f"Getting {self.config['name']} {year} paper URLs...")
+        try:
+            url = self.get_conference_url(year)
+            paper_urls = []
+            response = self.session.get(url)
+            if not response: 
+                return []
+            soup = BeautifulSoup(response.content, 'html.parser')
+            strong_tags = soup.find_all('strong')
+            for strong_tag in strong_tags[1:]:
+                a = strong_tag.find('a', href=True, class_='align-middle')
+                if a:
+                    paper_urls.append(self.base_url + a['href'])
+            logger.info(f"Found {len(paper_urls)} paper URLs")
+            return paper_urls
+            
+        except Exception as e:
+            logger.error(f"Failed to get paper URLs: {e}")
+            return []
+    
+    def parse_paper(self, url: str) -> Optional[Dict]:
+        """Parse a single paper."""
+        try:
+            response = self.session.get(url)
+            if not response:
+                return None
+            
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # TODO: Implement conference-specific parsing
+            # Common elements to extract:
+            
+            # 1. Title
+            title = self._extract_title(soup)
+            if not title:
+                logger.warning(f"No title found for {url}")
+                return None
+            
+            # 2. Authors
+            authors = self._extract_authors(soup)
+            
+            # 3. Abstract
+            abstract = self._extract_abstract(soup)
+            
+            # 4. Paper ID
+            paper_id = self._extract_paper_id(url)
+            
+            # 5. PDF URL
+            pdf_url = self._extract_pdf_url(soup, url)
+            
+            paper = {
+                'id': paper_id,
+                'title': title,
+                'authors': authors,
+                'abstract': abstract,
+                'pdf_url': pdf_url
+            }
+            
+            logger.debug(f"Parsed: {title}")
+            return paper
+            
+        except Exception as e:
+            logger.error(f"Failed to parse {url}: {e}")
+            return None
+    
+    def _extract_title(self, soup: BeautifulSoup) -> str:
+        title = ""
+        title = soup.find('h2', id='title')
+        if title:
+            return title.get_text().strip()
+        return "failed"
+    
+    def _extract_authors(self, soup: BeautifulSoup) -> List[str]:
+        authors = []
+        p_tag = soup.find('p', class_='lead')
+        if p_tag: 
+            a_tags = p_tag.find_all('a', href=True)
+            for a in a_tags:
+                authors.append(a.get_text().strip())
+            return authors
+        return []
+    
+    def _extract_abstract(self, soup: BeautifulSoup) -> str:
+       abstract = ""
+       h5_tag = soup.find('h5', class_='card-title')
+       if h5_tag: 
+           abstract = h5_tag.find_next_sibling('span').get_text().strip()
+       return abstract if abstract else "No abstract found"
+
+    
+    def _extract_paper_id(self, url: str) -> str:
+        import re
+        match = re.search(r'https://aclanthology.org/(.*)', url)
+        paper_id_with_slash = match.group(1) if match else ""
+        return paper_id_with_slash.rstrip('/')
+    
+    def _extract_pdf_url(self, soup: BeautifulSoup, page_url: str) -> str:
+        dt_tag = soup.find('dt', string='PDF:')
+        dd_tag = dt_tag.find_next_sibling('dd') if dt_tag else None
+        if dd_tag and dd_tag.a:
+            return dd_tag.a['href']
+        return ""
+    
+    def _make_absolute_url(self, url: str) -> str:
+        """Convert relative URL to absolute."""
+        from urllib.parse import urljoin
+        return urljoin(self.base_url, url)
+
+
+# Example scrapers for reference:
+
+class ICMLScraper(BaseScraper):
+    """ICML scraper - proceedings.mlr.press"""
+    
+    def __init__(self):
+        super().__init__('icml')
+    
+    def get_paper_urls(self, year: int) -> List[str]:
+        # ICML uses volume numbers, need to map year to volume
+        # This would need to be implemented based on ICML's structure
+        pass
+    
+    def parse_paper(self, url: str) -> Optional[Dict]:
+        # ICML has a specific format on MLR Press
+        pass

--- a/scrapers/aistats.py
+++ b/scrapers/aistats.py
@@ -1,0 +1,241 @@
+"""AISTATS scraper implementation."""
+import re
+from urllib.parse import urljoin, urlparse
+from bs4 import BeautifulSoup
+from typing import List, Dict, Optional
+import logging
+
+from .base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+
+class AISTATSScraper(BaseScraper):
+    """AISTATS conference scraper."""
+
+    def __init__(self):
+        super().__init__('aistats')
+        self._volume_cache = {}  # Cache year->volume mapping
+    
+    def _get_volume_for_year(self, year: int) -> Optional[str]:
+        """Get ICML volume identifier (e.g., 'v119') for the given year."""
+        if year in self._volume_cache:
+            return self._volume_cache[year]
+
+        logger.info(f"Finding AISTATS volume for year {year}...")
+
+        try:
+            response = self.session.get(self.base_url)
+            if not response or response.status_code != 200:
+                logger.error("Failed to fetch AISTATS proceedings main page")
+                return None
+
+            soup = BeautifulSoup(response.content, 'html.parser')
+
+            # Matches: "Proceedings of ICML 2022" or "ICML 2022 Proceedings"
+            aistats_pattern = re.compile(
+                #rf'(Proceedings\s+of\s+AISTATS\s+{year}|AISTATS\s+{year}\s+Proceedings)',
+                rf'\b(?:Proceedings\s+of\s+AISTATS\s+{year}|AISTATS\s+{year}\s+Proceedings)\b\s*$',
+                re.IGNORECASE
+            )
+
+            for li in soup.find_all('li'):
+                li_text = li.get_text().strip()
+                if aistats_pattern.search(li_text):
+                    link = li.find('a', href=True)
+                    if link:
+                        href = link['href']
+                        match = re.match(r'v\d+', href)
+                        if match:
+                            volume_id = match.group(0)
+                            self._volume_cache[year] = volume_id
+                            logger.info(f"Found AISTATS {year} volume: {volume_id}")
+                            return volume_id
+
+            logger.warning(f"No AISTATS volume found for year {year}")
+            return None
+
+        except Exception as e:
+            logger.error(f"Error while fetching AISTATS volume for year {year}: {e}")
+            return None
+    
+    def get_paper_urls(self, year: int) -> List[str]:
+        """Get paper URLs for AISTATS year."""
+        logger.info(f"Getting AISTATS {year} paper URLs...")
+        
+        # Get volume number
+        volume = self._get_volume_for_year(year)
+        if not volume:
+            return []
+        
+        # Construct volume URL
+        volume_url = f"{self.base_url}{volume}/"
+        
+        try:
+            response = self.session.get(volume_url)
+            if not response:
+                logger.error(f"Failed to fetch volume page: {volume_url}")
+                return []
+            
+            # Extract abstract URLs from paper divs
+            soup = BeautifulSoup(response.content, 'html.parser')
+            paper_urls = []
+            
+            for paper_div in soup.find_all('div', class_='paper'):
+                # Find the abs link
+                links_p = paper_div.find('p', class_='links')
+                if links_p:
+                    abs_link = links_p.find('a', string='abs')
+                    if abs_link and abs_link.get('href'):
+                        abs_url = urljoin(self.base_url, abs_link.get('href'))
+                        paper_urls.append(abs_url)
+            
+            logger.info(f"Found {len(paper_urls)} papers in volume {volume}")
+            return paper_urls
+            
+        except Exception as e:
+            logger.error(f"Error getting papers from {volume_url}: {e}")
+            return []
+    
+    def parse_paper(self, abs_url: str) -> Optional[Dict]:
+        """Parse a single ICML paper from its abstract URL."""
+        try:
+            # Get abstract from the abstract page
+            abstract = self._get_abstract_from_page(abs_url)
+            
+            # Get paper metadata from volume page
+            paper_metadata = self._get_paper_metadata_from_volume(abs_url)
+            
+            if not paper_metadata:
+                logger.warning(f"Could not get metadata for {abs_url}")
+                return None
+            
+            # Combine abstract with metadata
+            paper = paper_metadata.copy()
+            paper['abstract'] = abstract
+            
+            logger.debug(f"Parsed paper: {paper.get('title', 'Unknown')} ({len(paper.get('authors', []))} authors)")
+            return paper
+            
+        except Exception as e:
+            logger.error(f"Failed to parse {abs_url}: {e}")
+            return None
+    
+    def _get_abstract_from_page(self, abs_url: str) -> str:
+        """Extract abstract from abstract page."""
+        try:
+            response = self.session.get(abs_url)
+            if not response:
+                return ""
+            
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # Look for abstract div
+            abstract_div = soup.find('div', id='abstract', class_='abstract')
+            if abstract_div:
+                return abstract_div.get_text().strip()
+            
+            # Fallback: look for any div with class abstract
+            abstract_div = soup.find('div', class_='abstract')
+            if abstract_div:
+                return abstract_div.get_text().strip()
+            
+            logger.warning(f"No abstract found on {abs_url}")
+            return ""
+            
+        except Exception as e:
+            logger.error(f"Error getting abstract from {abs_url}: {e}")
+            return ""
+    
+    def _get_paper_metadata_from_volume(self, abs_url: str) -> Optional[Dict]:
+        """Get paper metadata from the volume page by finding the matching paper div."""
+        try:
+            # Extract volume from abs URL
+            # abs_url like: https://proceedings.mlr.press/v202/aamand23a.html
+            volume_match = re.search(r'/v(\d+)/', abs_url)
+            if not volume_match:
+                logger.error(f"Could not extract volume from {abs_url}")
+                return None
+            
+            volume = volume_match.group(1)
+            paper_id = self._extract_paper_id_from_abs_url(abs_url)
+            
+            # Get volume page
+            volume_url = f"{self.base_url}v{volume}/"
+            response = self.session.get(volume_url)
+            if not response:
+                return None
+            
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # Find the specific paper div by matching the abs link
+            for paper_div in soup.find_all('div', class_='paper'):
+                links_p = paper_div.find('p', class_='links')
+                if links_p:
+                    abs_link = links_p.find('a', string='abs')
+                    if abs_link and abs_link.get('href'):
+                        div_abs_url = urljoin(self.base_url, abs_link.get('href'))
+                        if div_abs_url == abs_url:
+                            # Found the matching div, extract metadata
+                            return self._extract_metadata_from_paper_div(paper_div, volume)
+            
+            logger.warning(f"Could not find paper div for {abs_url}")
+            return None
+            
+        except Exception as e:
+            logger.error(f"Error getting metadata for {abs_url}: {e}")
+            return None
+    
+    def _extract_metadata_from_paper_div(self, paper_div, volume: str) -> Dict:
+        """Extract metadata from a paper div element."""
+        metadata = {}
+        
+        # Extract title
+        title_p = paper_div.find('p', class_='title')
+        if title_p:
+            metadata['title'] = title_p.get_text().strip()
+        
+        # Extract authors and other details
+        details_p = paper_div.find('p', class_='details')
+        if details_p:
+            authors_span = details_p.find('span', class_='authors')
+            if authors_span:
+                author_text = authors_span.get_text(separator=' ', strip=True)
+            
+                # Replace non-breaking spaces with regular space
+                author_text = author_text.replace('\xa0', ' ')
+
+                # Authors are typically split by ', '
+                authors = [a.strip() for a in author_text.split(',') if a.strip()]
+                
+                metadata['authors'] = authors
+            
+        # Extract PDF URL from links
+        links_p = paper_div.find('p', class_='links')
+        if links_p:
+            pdf_link = None
+            for link in links_p.find_all('a'):
+                if 'Download PDF' in link.get_text() or link.get_text().strip() == 'pdf':
+                    pdf_link = link.get('href')
+                    break
+            
+            if pdf_link:
+                metadata['pdf_url'] = urljoin(self.base_url, pdf_link)
+        
+        # Extract paper ID from the abs link or PDF link
+        if links_p:
+            abs_link = links_p.find('a', string='abs')
+            if abs_link and abs_link.get('href'):
+                metadata['id'] = self._extract_paper_id_from_abs_url(abs_link.get('href'))
+        
+        return metadata
+    
+    def _extract_paper_id_from_abs_url(self, abs_url: str) -> str:
+        """Extract paper ID from abstract URL."""
+        # Pattern: /v202/aamand23a.html -> aamand23a
+        match = re.search(r'/v\d+/([^/]+)\.html', abs_url)
+        if match:
+            return match.group(1)
+        
+        # Fallback: use filename without extension
+        return abs_url.split('/')[-1].replace('.html', '')

--- a/scrapers/cvpr.py
+++ b/scrapers/cvpr.py
@@ -107,15 +107,12 @@ class CVPRScraper(BaseScraper):
             return None
     
     def _extract_title(self, soup: BeautifulSoup) -> str:
-        """Extract paper title."""
         title = ""
-        title_id = soup.find(id='papertitle')
-        if title_id:
-            title = title_id.get_text().strip()
-            if title and len(title) > 3:
+        h2_tag = soup.find('h2')
+        if h2_tag: 
+            title = h2_tag.get_text().strip()
+            if title: 
                 return title
-
-        return ""
     
     def _extract_authors(self, soup: BeautifulSoup) -> List[str]:
         """Extract authors."""

--- a/scrapers/ijcai.py
+++ b/scrapers/ijcai.py
@@ -1,0 +1,185 @@
+# scrapers/template.py
+"""Template for implementing new conference scrapers."""
+
+from typing import List, Dict, Optional
+import logging
+from bs4 import BeautifulSoup
+import os
+import json
+from .base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+
+class IJCAIScraper(BaseScraper):
+    """IJCAI scraper - copy this to create new conference scrapers."""
+    
+    def __init__(self):
+        # Replace 'template' with actual conference name (must match config.py)
+        super().__init__('ijcai')
+    def labeled_json_exists(self) -> bool:
+        return os.path.exists("data/ijcai/labeled.json")
+
+    def load_labeled_tracks(self) -> dict:
+        with open("data/ijcai/labeled.json") as f:
+            return json.load(f)
+        
+    def get_track_names(self, url: str) -> list:
+        response = self.session.get(url)
+        if not response:
+            logger.error(f"Failed to fetch {url}")
+            return []
+        soup = BeautifulSoup(response.content, 'html.parser')
+        section_tags = soup.find_all('div', class_='section_title')
+        track_names = set()
+        for section in section_tags:
+            h3_tag = section.find('h3')
+            if h3_tag:
+                track_name = h3_tag.get_text(strip=True).lower()
+                track_names.add(track_name)
+        return list(track_names)
+
+    def get_relevant_tracks(self, year: int, labeled_tracks: dict) -> list:
+        year_str = str(year)
+        if year_str not in labeled_tracks:
+            return []
+        relevant_tracks = []
+        for track in labeled_tracks[year_str]["tracks"]:
+            if track.get("is_full_regular"):
+                relevant_tracks.append(track["name"].lower())
+        return relevant_tracks
+
+    def get_paper_urls(self, year: int) -> list:
+        logger.info(f"Getting {self.config['name']} {year} paper URLs...")
+        year_str = str(year)
+        if self.labeled_json_exists():
+            labeled_tracks = self.load_labeled_tracks()
+            if year_str in labeled_tracks:
+                relevant_tracks = self.get_relevant_tracks(year, labeled_tracks)
+                logger.info(f"Relevant tracks for {year}: {relevant_tracks}")
+                paper_urls = []
+                url = f"{self.base_url}/proceedings/{year}/"
+                resposne = self.session.get(url)
+                if not resposne:
+                    logger.error(f"Failed to fetch {url}")
+                    return []
+                soup = BeautifulSoup(resposne.content, 'html.parser')
+                section_tags = soup.find_all('div', class_='section')
+                for section in section_tags:
+                    track_name = section.find('h3').get_text(strip=True).lower()
+                    if track_name in relevant_tracks:
+                        div_tags = section.find_all('div', class_="details")
+                        for div in div_tags:
+                            a_tags = div.find_all('a', href=True)
+                            a_tag = a_tags[1]
+                            if a_tag:
+                                final_url = self.base_url + a_tag['href']
+                                paper_urls.append(final_url)
+                return paper_urls                
+
+
+        url = f"{self.base_url}/proceedings/{year}/"
+        all_tracks = self.get_track_names(url)
+        unlabeled_json = {
+            year_str: {
+                "tracks": [{"name": t} for t in all_tracks]
+            }
+        }
+        os.makedirs("data/ijcai", exist_ok=True)
+        with open(f"data/ijcai/unlabeled_{year}.json", "w") as f:
+            json.dump(unlabeled_json, f, indent=2)
+        logger.warning(
+            f"Unlabeled track list for {year} written to data/ijcai/unlabeled_{year}.json. "
+            "Please label this file using GPT and save as data/ijcai/labeled.json, then rerun."
+        )
+        exit(0)
+    
+    def parse_paper(self, url: str) -> Optional[Dict]:
+        """Parse a single paper."""
+        try:
+            response = self.session.get(url)
+            if not response:
+                return None
+            
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # TODO: Implement conference-specific parsing
+            # Common elements to extract:
+            
+            # 1. Title
+            title = self._extract_title(soup)
+            if not title:
+                logger.warning(f"No title found for {url}")
+                return None
+            
+            # 2. Authors
+            authors = self._extract_authors(soup)
+            
+            # 3. Abstract
+            abstract = self._extract_abstract(soup)
+            
+            # 4. Paper ID
+            paper_id = self._extract_paper_id(url)
+            
+            # 5. PDF URL
+            pdf_url = self._extract_pdf_url(soup, url)
+            
+            paper = {
+                'id': paper_id,
+                'title': title,
+                'authors': authors,
+                'abstract': abstract,
+                'pdf_url': pdf_url
+            }
+            
+            logger.debug(f"Parsed: {title}")
+            return paper
+            
+        except Exception as e:
+            logger.error(f"Failed to parse {url}: {e}")
+            return None
+    
+    def _extract_title(self, soup: BeautifulSoup) -> str:
+        h1_tags = soup.find_all('h1')
+        if h1_tags:
+            title = h1_tags[1].get_text(strip=True)
+            if title:
+                return title
+        return ""
+    
+    def _extract_authors(self, soup: BeautifulSoup) -> List[str]:
+        h2_tag = soup.find('h2')
+        if h2_tag:
+            author_text = h2_tag.get_text(strip=True)
+            authors = [author.strip() for author in author_text.split(',') if author.strip()]
+            return authors
+        return []
+    
+    def _extract_abstract(self, soup: BeautifulSoup) -> str:
+        div_tag = soup.find('div', class_='col-md-12')
+        if div_tag:
+            return div_tag.get_text(strip=True)
+        return ""
+    
+    def _extract_paper_id(self, url: str) -> str:       
+        import re
+
+        pattern = r'/proceedings/(\d{4})/(\d+)'
+        match = re.search(pattern, url)
+        if match:
+            return f"{match.group(1)}-{match.group(2)}"
+        return ""
+    
+    def _extract_pdf_url(self, soup: BeautifulSoup, page_url: str) -> str:
+        a_tag = soup.find('a', href=True, class_="button btn-lg btn-download")
+        if a_tag: 
+            return a_tag['href']
+        return ""
+    
+    def _make_absolute_url(self, url: str) -> str:
+        """Convert relative URL to absolute."""
+        from urllib.parse import urljoin
+        return urljoin(self.base_url, url)
+
+
+# Example scrapers for reference:

--- a/scrapers/jmlr.py
+++ b/scrapers/jmlr.py
@@ -1,0 +1,170 @@
+from typing import List, Dict, Optional
+import logging
+from bs4 import BeautifulSoup
+from .base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+
+class JMLRScraper(BaseScraper):
+    """JMLR scraper."""
+
+    def __init__(self):
+        super().__init__('jmlr')
+    
+    def get_paper_urls(self, year: int) -> List[str]:
+        """Get paper URLs for a given year."""
+        from urllib.parse import urljoin
+        logger.info(f"Getting {self.config['name']} {year} paper URLs...")
+        self.year = year
+        
+        try:
+            volume = year - 1999 
+            url = f"{self.base_url}/papers/v{volume}/"
+            response = self.session.get(url)
+            if not response:
+                return []
+            
+            soup = BeautifulSoup(response.content, 'html.parser')
+            paper_urls = []
+        #https://www.jmlr.org/papers/v1/meila00a.html
+            dl_tags = soup.find_all('dl')
+            for dl in dl_tags:
+                dd_tag = dl.find('dd')
+                if dd_tag:
+                    a_tag = dd_tag.find('a', href=True, string=lambda s: s and 'abs' in s.lower())
+                    if a_tag:
+                        href = a_tag['href']
+                        if href:
+                            full_url = urljoin(self.base_url + f"/papers/v{volume}/", href)
+                            paper_urls.append(full_url)           
+            logger.info(f"Found {len(paper_urls)} paper URLs")
+            return paper_urls
+            
+        except Exception as e:
+            logger.error(f"Failed to get paper URLs: {e}")
+            return []
+    
+    def parse_paper(self, url: str) -> Optional[Dict]:
+        """Parse a single paper."""
+        try:
+            response = self.session.get(url)
+            if not response:
+                return None
+            
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # TODO: Implement conference-specific parsing
+            # Common elements to extract:
+            
+            # 1. Title
+            title = self._extract_title(soup)
+            if not title:
+                logger.warning(f"No title found for {url}")
+                return None
+            
+            # 2. Authors
+            authors = self._extract_authors(soup)
+            
+            # 3. Abstract
+            abstract = self._extract_abstract(soup)
+            
+            # 4. Paper ID
+            paper_id = self._extract_paper_id(url)
+            
+            # 5. PDF URL
+            pdf_url = self._extract_pdf_url(soup, url)
+            
+            paper = {
+                'id': paper_id,
+                'title': title,
+                'authors': authors,
+                'abstract': abstract,
+                'pdf_url': pdf_url
+            }
+            
+            logger.debug(f"Parsed: {title}")
+            return paper
+            
+        except Exception as e:
+            logger.error(f"Failed to parse {url}: {e}")
+            return None
+    
+    def _extract_title(self, soup: BeautifulSoup) -> str:
+        """Extract paper title."""
+        # TODO: Conference-specific title extraction
+        # Common selectors: h1, h2, .title, .paper-title, #title
+        
+        selectors = ['h1', 'h2', '.title', '.paper-title', '#title']
+        for selector in selectors:
+            elem = soup.select_one(selector)
+            if elem:
+                title = elem.get_text().strip()
+                if title and len(title) > 3:
+                    return title
+        
+        return ""
+    
+    def _extract_authors(self, soup: BeautifulSoup) -> List[str]:
+        authors = ""
+        i_tag = soup.find('i')
+        if i_tag:
+            author_text = i_tag.get_text().strip()
+            if author_text: 
+                authors = author_text.split(',')
+                authors = [author.strip() for author in authors]
+        return authors
+
+    
+    def _extract_abstract(self, soup: BeautifulSoup) -> str:
+        abstract = ""
+        p_tag = soup.find('p', class_='abstract')
+        if p_tag:
+            abstract = p_tag.get_text().strip()
+            if abstract:
+                return abstract
+        h3_tag = soup.find('h3', string=lambda s: s and s.strip().lower() == "abstract") #for volume 5 and below
+        if h3_tag:
+            abstract_parts = []
+            for sib in h3_tag.next_siblings:
+                if getattr(sib, 'name', None) in ('font', 'p', 'h3', 'h2', 'h1', 'div'):
+                    break
+                
+                if hasattr(sib, 'get_text'):
+                    text = sib.get_text(separator=' ', strip=True) #im putting a space here for the nested tags
+                    if text:
+                        text = text.replace('\n', '').replace('\r', ' ').strip()
+                        abstract_parts.append(text)
+                
+                elif hasattr(sib, 'strip'):
+                    text = sib.strip()
+                    if text:
+                        text = text.replace('\n', '').replace('\r', ' ').strip()
+                        abstract_parts.append(text)
+            abstract = ' '.join(abstract_parts)
+            return abstract
+        return ""
+    
+    def _extract_paper_id(self, url: str) -> str:
+        import re
+        # https://www.jmlr.org/papers/v1/meila00a.html
+        match = re.search(r'v\d+/([^/]+)\.html', url)
+        if match: 
+            return match.group(1)
+        return ""
+    
+    def _extract_pdf_url(self, soup: BeautifulSoup, page_url: str) -> str:
+        pdf_url = ""
+        a_tag = soup.find('a', string=lambda s: s and 'pdf' in s.lower())
+        if a_tag: 
+            href = a_tag['href']
+            if href:
+                pdf_url = self._make_absolute_url(href)
+                return pdf_url
+
+
+    
+    def _make_absolute_url(self, url: str) -> str:
+        """Convert relative URL to absolute."""
+        from urllib.parse import urljoin
+        return urljoin(self.base_url, url)


### PR DESCRIPTION
## Summary
Add scrapers for AISTATS, ACL, JMLR, and IJCAI conferences to collect academic papers.

## Current Status
✅ AISTATS scraper - working correctly
✅ JMLR scraper - working correctly  
✅ IJCAI scraper - working correctly
❌ ACL scraper - needs fix

## Issue with ACL Scraper
The ACL scraper currently includes all papers in the proceeding without filtering for **regular full papers**. As mentioned in our previous email: **"Please only include regular full papers and skip other categories."**

## Required Fix
The ACL scraper needs to follow the same logic as the IJCAI scraper:
1. First generate a JSON file with all papers
2. User will use ChatGPT to annotate which papers are "regular full papers"
3. Put the annotated file back into the repository
4. Re-run the scraper to filter only the annotated regular papers

@shivskills Could you please update the ACL scraper to match the IJCAI implementation? The current version doesn't consider whether volumes contain regular full papers vs other categories.

## Next Steps
- [x] Fix ACL scraper to generate JSON for manual annotation
- [x] Test the updated scraper
- [x] Ready for merge